### PR TITLE
Add release workflow to build binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -30,12 +30,16 @@ jobs:
       - name: Stage binary
         run: cp ohdear-system-health ohdear-system-health-linux-amd64
 
+      - name: Generate SHA-512 checksum
+        run: sha512sum ohdear-system-health-linux-amd64 > ohdear-system-health-linux-amd64.sha512
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ inputs.version }}" \
             ohdear-system-health-linux-amd64 \
+            ohdear-system-health-linux-amd64.sha512 \
             --repo "${{ github.repository }}" \
             --title "${{ inputs.version }}" \
             --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+# Manually triggered from the Actions tab. Builds the binary with `make all`
+# and publishes it as an asset on a new GitHub Release.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag (e.g. v1.0.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: make all
+
+      - name: Stage binary
+        run: cp ohdear-system-health ohdear-system-health-linux-amd64
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ inputs.version }}" \
+            ohdear-system-health-linux-amd64 \
+            --repo "${{ github.repository }}" \
+            --title "${{ inputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
First part of https://github.com/php/infrastructure/issues/27

Check this Repo's Actions write permission: Settings → Actions → General → Workflow permissions → ensure "Read and write permissions" is enabled.

To run the workflow: [github.com/derickr/ohdear-system-health](https://github.com/derickr/ohdear-system-health) → Actions tab → Release → Run workflow, enter a tag ~ v1.0.0. We can also wire this up to run on release if you want to tag specific releases.

You can see the test run on my fork: https://github.com/svpernova09/ohdear-system-health/actions/runs/27467730562 and the test release: https://github.com/svpernova09/ohdear-system-health/releases/tag/v0.0.0